### PR TITLE
WorkflowRun: Fix job.queued_duration_second

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ This action sends the following metrics if enabled.
 - `github.actions.job.duration_second`
   - Time from a job is started to completed
 - `github.actions.job.queued_duration_second`
-  - Time from a job is started until the first step is started
+  - Time from a workflow is started until the first step of this job is started
 
 It has the following tags:
 

--- a/src/workflowRun/metrics.ts
+++ b/src/workflowRun/metrics.ts
@@ -143,7 +143,8 @@ export const computeJobMetrics = (
 
     if (checkRun.steps.nodes.length > 0) {
       const firstStepStartedAt = Math.min(...checkRun.steps.nodes.map((s) => unixTime(s.startedAt)))
-      const queued = firstStepStartedAt - startedAt
+      const workflowRunStartedAt = unixTime(e.workflow_run.run_started_at)
+      const queued = firstStepStartedAt - workflowRunStartedAt
       series.push({
         host: 'github.com',
         tags,

--- a/tests/workflowRun/fixtures/metrics.ts
+++ b/tests/workflowRun/fixtures/metrics.ts
@@ -202,7 +202,7 @@ export const exampleJobMetrics: v1.Series[] = [
   {
     host: 'github.com',
     metric: 'github.actions.job.queued_duration_second',
-    points: [[1579542279, 0]],
+    points: [[1579542279, -179428]],
     tags: [
       'repository_owner:octocat',
       'repository_name:Hello-World',


### PR DESCRIPTION
It's not really that useful to have the time from when a job starts
until the time when the first step starts. That's always 0 or close to
0.

Instead, let's track the time of when the workflow starts until the
first step of the job is started. This better represents how long the
job has been queued.

QA:
--
Make sure the tests run and pass.

Closes: https://github.com/iFixit/ifixit/issues/44394
Connects: https://github.com/int128/datadog-actions-metrics/issues/285

cc @iFixit/qae 